### PR TITLE
Support a CentOS-based image

### DIFF
--- a/1.6/centos/Dockerfile
+++ b/1.6/centos/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:7
+
+RUN	groupadd -r spiped \
+&&	useradd -r -g spiped spiped
+
+ENV SPIPED_VERSION 1.6.0
+ENV SPIPED_DOWNLOAD_URL https://www.tarsnap.com/spiped/spiped-1.6.0.tgz
+ENV SPIPED_DOWNLOAD_SHA256 e6f7f8f912172c3ad55638af8346ae7c4ecaa92aed6d3fb60f2bda4359cba1e4
+
+RUN set -x \
+&&	buildDeps='openssl-devel glibc-devel gcc make' \
+&&	yum -y update && yum -y install $buildDeps \
+&&	curl -fsSL "$SPIPED_DOWNLOAD_URL" -o spiped.tar.gz \
+&&	echo "$SPIPED_DOWNLOAD_SHA256 spiped.tar.gz" |sha256sum -c - \
+&&	mkdir -p /usr/local/src/spiped \
+&&	tar xzf "spiped.tar.gz" -C /usr/local/src/spiped --strip-components=1 \
+&&	rm "spiped.tar.gz" \
+&&	make -C /usr/local/src/spiped \
+&&	make -C /usr/local/src/spiped install \
+&&	rm -rf /usr/local/src/spiped \
+&&	yum -y remove $buildDeps \
+&&	yum clean all \
+&&	rm -rf /var/cache/yum
+
+VOLUME /spiped
+WORKDIR /spiped
+
+COPY *.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["spiped"]

--- a/1.6/centos/docker-entrypoint.sh
+++ b/1.6/centos/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+	-*) set -- spiped -k /spiped/key -F "$@" ;;
+esac
+
+exec "$@"

--- a/1.6/centos/spiped-generate-key.sh
+++ b/1.6/centos/spiped-generate-key.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+umask 0077
+dd if=/dev/urandom bs=32 count=1 of=/spiped/key/spiped-keyfile


### PR DESCRIPTION
Debian-based images sometimes generate random core dumps with RedHat-based host kernels. Thus the need for this.