### PR TITLE
Replace `libssl3` with `libssl3t64`

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -7,7 +7,7 @@ RUN	set -x \
 RUN	export DEBIAN_FRONTEND="noninteractive" \
 &&	set -x \
 &&	apt-get update \
-&&	apt-get install -y libssl3 --no-install-recommends \
+&&	apt-get install -y libssl3t64 --no-install-recommends \
 &&	rm -rf /var/lib/apt/lists/*
 
 ENV	SPIPED_VERSION=1.6.4 SPIPED_DOWNLOAD_SHA256=424fb4d3769d912b04de43d21cc32748cdfd3121c4f1d26d549992a54678e06a


### PR DESCRIPTION
In Trixie+, the `libssl3` package has been renamed for the time64 transition.

I'm not sure why it only seems to fail to build on arm32v7, but this fix works on both (because this is the new appropriate name for this package).

(See also https://github.com/varnish/docker-varnish/pull/90, which is the same weird issue but a different library)